### PR TITLE
Use ubuntu latest in github actions

### DIFF
--- a/.github/workflows/acr-build-and-push.yaml
+++ b/.github/workflows/acr-build-and-push.yaml
@@ -37,5 +37,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ env.AZURE_CONTAINER_REGISTRY_URL }}/zap-glue:${{ steps.prep.outputs.BUILD_ID }}

--- a/.github/workflows/acr-build.yaml
+++ b/.github/workflows/acr-build.yaml
@@ -35,5 +35,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ env.AZURE_CONTAINER_REGISTRY_URL }}/zap-glue:pr-${{ steps.prep.outputs.BUILD_ID }}


### PR DESCRIPTION
### Jira link

See [DTSPO-29095](https://tools.hmcts.net/jira/browse/DTSPO-29095)

### Change description

Update actions to use `ubuntu-latest`
Existing version is no longer supported by GitHub so the actions haven't ran for a while
Temporarily removed the arm64 image as it's causing failures in the pipeline
We're not using arm64 jenkins agent at the moment so this isn't an issue but will try to fix in a subsequent PR

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
