### PR TITLE
DTSPO-2905 - Move QEMU setup before docker build setup

### DIFF
--- a/.github/workflows/acr-build-and-push.yaml
+++ b/.github/workflows/acr-build-and-push.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Azure Container Repository
         uses: docker/login-action@v3
         with:
@@ -37,5 +37,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.AZURE_CONTAINER_REGISTRY_URL }}/zap-glue:${{ steps.prep.outputs.BUILD_ID }}

--- a/.github/workflows/acr-build.yaml
+++ b/.github/workflows/acr-build.yaml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Azure Container Repository
         uses: docker/login-action@v3
         with:
@@ -35,5 +35,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.AZURE_CONTAINER_REGISTRY_URL }}/zap-glue:pr-${{ steps.prep.outputs.BUILD_ID }}


### PR DESCRIPTION
### Jira link

See [DTSPO-29095](https://tools.hmcts.net/jira/browse/DTSPO-2905)

### Change description

[Suggested fix](https://github.com/docker/build-push-action/issues/1436#issuecomment-3625625964) for issues in arm64 build

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
