### PR TITLE
DTSPO-29095 - Use github-releases and update matchStrings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,20 +11,9 @@
         "/Dockerfile$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+        "#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
-  "packageRules": [
-    {
-      "matchDatasources": [
-        "github-tags"
-      ],
-      "matchPackageNames": [
-        "trufflesecurity/trufflehog"
-      ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:3.4.8-trixie
+FROM ruby:3.4.7-trixie
 
 ################################################################################################
 #       Environment
-#renovate: datasource=github-tags depName=trufflesecurity/trufflehog
+#renovate: datasource=github-releases depName=trufflesecurity/trufflehog extractVersion=^v(?<version>.*)$
 ARG TRUFFLEHOG_VERSION=3.92.3
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### Jira link

See [DTSPO-29095](https://tools.hmcts.net/jira/browse/DTSPO-29095)

### Change description

Update `matchStrings`
Try using github releases instead

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
