### PR TITLE
Update apt command to bypass gpg issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /e
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
 RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo -H gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
 RUN sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
-RUN sudo apt-get update
+RUN sudo apt-get update -o APT::Key::GPGVCommand=1
 RUN sudo apt-get install sbt
 
 RUN mkdir -p /home/glue/.sbt/0.13/plugins


### PR DESCRIPTION
### Change description

As of 1st February 2026, SHA1 GPG keys are no longer accepted by apt by default
New upstream key doesn't appear to have been created so adding this temporary bypass
Watching https://github.com/sbt/sbt/issues/8680 for updates

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
